### PR TITLE
Update implement-microsoft-passport-in-your-organization.md

### DIFF
--- a/windows/keep-secure/implement-microsoft-passport-in-your-organization.md
+++ b/windows/keep-secure/implement-microsoft-passport-in-your-organization.md
@@ -20,7 +20,7 @@ localizationpriority: high
 You can create a Group Policy or mobile device management (MDM) policy that will implement Windows Hello on devices running Windows 10.
 
 >[!IMPORTANT]
->The Group Policy setting **Turn on PIN sign-in** does not apply to Windows Hello for Business. It still prevents or enables the creation of a convenience PIN for Windows 10, version 1507 and 1511. 
+>The Group Policy setting **Turn on PIN sign-in** does not apply to Windows Hello for Business. It still prevents or enables the creation of a convenience PIN for Windows 10, version 1507, 1511, and 1607. 
 >
 >Beginning in version 1607, Windows Hello as a convenience PIN is disabled by default on all domain-joined computers. To enable a convenience PIN for Windows 10, version 1607, enable the Group Policy setting **Turn on convenience PIN sign-in**. 
 >


### PR DESCRIPTION
I am managing a server with Windows Server 2012 R2 Essentials (build 9600) and this text misled me to believe that **Turn on PIN sign-in** group policy did not affect the convenience PIN for computers running version 1607. Server-side group policies relevant to the Windows Hello for Business component are not available until Windows Server 2016. After further research and experimentation, I found that enabling **Turn on PIN sign-on** via group policy object set by the server does affect the **Turn on convenience PIN sign-in** local policy of a client running version 1607.