### PR TITLE
Update appendix-a-powershell-scripts-for-surface-hub.md

### DIFF
--- a/devices/surface-hub/appendix-a-powershell-scripts-for-surface-hub.md
+++ b/devices/surface-hub/appendix-a-powershell-scripts-for-surface-hub.md
@@ -1620,7 +1620,7 @@ In the following cmdlets, `$strPolicy` is the name of the ActiveSync policy, and
 
 Note that in order to run the cmdlets, you need to set up a remote PowerShell session and:
 
--   Your admin account must be remote-PowerShell-enabled. This allows the admin to use the PowerShell cmdlets that are needed by the script. (This permission can be set using set-user `$admin -RemotePowerShellEnabled $true`)
+-   Your admin account must be remote-PowerShell-enabled. This allows the admin to use the PowerShell cmdlets that are needed by the script. (This permission can be set using `set-user $admin -RemotePowerShellEnabled $true`)
 -   Your admin account must have the "Reset Password" role if you plan to run the creation scripts. This allows the admin to change the password of the account, which is needed for the script. The Reset Password Role can be enabled using the Exchange Admin Center.
 
 Create the policy.


### PR DESCRIPTION
minor change to formatting where cmdlet wasn't marked as code but arguments were. It previously appeared at first glance that the PS to execute was 
$admin -RemotePowerShellEnabled $true
rather than
set-user $admin -RemotePowerShellEnabled $true