### PR TITLE
Update save-bitlocker-key-surface-hub.md

### DIFF
--- a/devices/surface-hub/save-bitlocker-key-surface-hub.md
+++ b/devices/surface-hub/save-bitlocker-key-surface-hub.md
@@ -24,7 +24,7 @@ There are several ways to manage your BitLocker key on the Surface Hub.
 
 2.  If you’ve joined the Surface Hub to Azure Active Directory (Azure AD), the BitLocker key will be stored under the account that was used to join the device.
 
-3.  If you’re using a local admin account to manage the device, you can save the BitLocker key by going to the **Settings** app and navigating to **Update & security** &gt; **Recovery**. Insert a USB drive and select the option to save the BitLocker key. The key will be saved to a text file on the USB drive.
+3.  If you’re using an admin account to manage the device, you can save the BitLocker key by going to the **Settings** app and navigating to **Update & security** &gt; **Recovery**. Insert a USB drive and select the option to save the BitLocker key. The key will be saved to a text file on the USB drive.
 
 
 ## Related topics


### PR DESCRIPTION
changed "local admin account" to "an admin account"  Since any of the three type of admin accounts can perform this function.