### PR TITLE
Added caveat for line 110: group membership in offline migration

### DIFF
--- a/windows/deploy/usmt-what-does-usmt-migrate.md
+++ b/windows/deploy/usmt-what-does-usmt-migrate.md
@@ -107,7 +107,7 @@ The following components are migrated by default using the manifest files:
 
 -   Fonts
 
--   Group membership. USMT migrates users’ group settings. The groups to which a user belongs can be found by right-clicking **My Computer** on the Start menu and then clicking **Manage**.
+-   Group membership. USMT migrates users’ group settings. The groups to which a user belongs can be found by right-clicking **My Computer** on the Start menu and then clicking **Manage**. When running an offline migration, the use of a **&lt;ProfileControl&gt;** section in the Config.xml file is required.
 
 -   \*Windows Internet Explorer® settings
 


### PR DESCRIPTION
Per [Offline Migration Reference](https://technet.microsoft.com/en-us/itpro/windows/deploy/offline-migration-reference), user-group memberships are *not* migrated by default. Use of the **&lt;ProfileControl&gt;** section in Config.xml is required.