### PR TITLE
Unintended usmt migration

### DIFF
--- a/windows/deployment/usmt/usmt-requirements.md
+++ b/windows/deployment/usmt/usmt-requirements.md
@@ -30,6 +30,7 @@ The User State Migration Tool (USMT) 10.0 does not have any explicit RAM or CPU
 The following table lists the operating systems supported in USMT.
 
 <table>
+
 <colgroup>
 <col width="33%" />
 <col width="33%" />
@@ -83,7 +84,8 @@ You can migrate a 32-bit operating system to a 64-bit operating system. However,
 
 USMT does not support any of the Windows Server® operating systems, Windows 2000, Windows XP, or any of the starter editions for Windows Vista or Windows 7.
 
- 
+USMT for Windows 10 should not be used for migrating from Windows 7 to Windows 8.1. It is meant to migrate to Windows 10.
+For more information about previous releases of the USMT tools, see [User State Migration Tool (USMT) 4.0 User’s Guide](https://go.microsoft.com/fwlink/p/?LinkId=246564). 
 
 ## Windows PE
 


### PR DESCRIPTION
The usmt from the adk for windows 10 is meant to migrate settings from these lower operating systems to windows 10 and not among each other.