### PR TITLE
Ntkd kernel debugger addition

### DIFF
--- a/windows/device-security/device-guard/deploy-code-integrity-policies-steps.md
+++ b/windows/device-security/device-guard/deploy-code-integrity-policies-steps.md
@@ -40,6 +40,7 @@ Unless your use scenarios explicitly require them, Microsoft recommends that you
 - fsi.exe
 - fsiAnyCpu.exe
 - kd.exe
+- ntkd.exe
 - lxssmanager.dll
 - msbuild.exe<sup>[1]</sup>
 - mshta.exe
@@ -102,6 +103,7 @@ Microsoft recommends that you block the following Microsoft-signed applications 
     <Deny  ID="ID_DENY_BGINFO"        FriendlyName="bginfo.exe"         FileName="BGINFO.Exe" MinimumFileVersion = "4.21.0.0" />
     <Deny  ID="ID_DENY_CBD"           FriendlyName="cdb.exe"            FileName="CDB.Exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_KD"            FriendlyName="kd.exe"             FileName="kd.Exe" MinimumFileVersion = "65535.65535.65535.65535" />
+    <Deny  ID="ID_DENY_NTKD"          FriendlyName="ntkd.exe"           FileName="ntkd.Exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_WINDBG"        FriendlyName="windbg.exe"         FileName="windbg.Exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_MSBUILD"       FriendlyName="MSBuild.exe"        FileName="MSBuild.Exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_CSI"           FriendlyName="csi.exe"            FileName="csi.Exe" MinimumFileVersion = "65535.65535.65535.65535" />
@@ -168,6 +170,7 @@ Microsoft recommends that you block the following Microsoft-signed applications 
           <FileRuleRef RuleID="ID_DENY_BGINFO"/>
           <FileRuleRef RuleID="ID_DENY_CBD"/>
           <FileRuleRef RuleID="ID_DENY_KD"/>
+          <FileRuleRef RuleID="ID_DENY_NTKD"/>
           <FileRuleRef RuleID="ID_DENY_WINDBG"/>
           <FileRuleRef RuleID="ID_DENY_MSBUILD"/>
           <FileRuleRef RuleID="ID_DENY_CSI"/>

--- a/windows/device-security/device-guard/deploy-code-integrity-policies-steps.md
+++ b/windows/device-security/device-guard/deploy-code-integrity-policies-steps.md
@@ -38,6 +38,7 @@ Unless your use scenarios explicitly require them, Microsoft recommends that you
 - csi.exe
 - dnx.exe
 - fsi.exe
+- fsiAnyCpu.exe
 - kd.exe
 - lxssmanager.dll
 - msbuild.exe<sup>[1]</sup>
@@ -110,6 +111,7 @@ Microsoft recommends that you block the following Microsoft-signed applications 
     <Deny  ID="ID_DENY_LXSS"          FriendlyName="LxssManager.dll"    FileName="LxssManager.dll" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_BASH"          FriendlyName="bash.exe"           FileName="bash.exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_FSI"           FriendlyName="fsi.exe"            FileName="fsi.exe" MinimumFileVersion = "65535.65535.65535.65535" />
+    <Deny  ID="ID_DENY_FSI_ANYCPU"    FriendlyName="fsiAnyCpu.exe"      FileName="fsiAnyCpu.exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_MSHTA"         FriendlyName="mshta.exe"          FileName="mshta.exe" MinimumFileVersion = "65535.65535.65535.65535" />
     <Deny  ID="ID_DENY_SMA"           FriendlyName="System.Management.Automation.dll" FileName="System.Management.Automation.dll" MinimumFileVersion = "10.0.16215.999" />
 
@@ -175,6 +177,7 @@ Microsoft recommends that you block the following Microsoft-signed applications 
           <FileRuleRef RuleID="ID_DENY_LXSS"/>
           <FileRuleRef RuleID="ID_DENY_BASH"/>
           <FileRuleRef RuleID="ID_DENY_FSI"/>
+          <FileRuleRef RuleID="ID_DENY_FSI_ANYCPU"/>
           <FileRuleRef RuleID="ID_DENY_MSHTA"/>
           <FileRuleRef RuleID="ID_DENY_SMA"/>
           <FileRuleRef RuleID="ID_DENY_D_1" />


### PR DESCRIPTION
ntkd is a kernel debugger that is nearly identical to the already blocked kd.exe binary.